### PR TITLE
Add 'to-web' as a rake task for dependent projects

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,13 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
+task :default => :spec
+
+# Require in rake-to-web's lib directory, so this project can run
+# 'rake to-web'
+require 'rake-to-web'
+
+# Some basic configuration / testing if you run rake to-web locally.
 task :hello_world do
   puts "HELLO WORLD"
 end
@@ -40,5 +47,3 @@ end
 task :goodbye_world do
   puts "GOODBYE WORLD"
 end
-
-task :default => :spec

--- a/lib/rake-to-web.rb
+++ b/lib/rake-to-web.rb
@@ -1,2 +1,12 @@
 require_relative 'rake_task_manager'
 require_relative 'task_to_web_builder'
+
+require 'rake'
+
+task = Rake::Task.define_task 'to-web' do
+  require 'rake-to-web'
+  rake_task_manager = RakeTaskManager.new
+  builder = TaskToWebBuilder.new rake_task_manager
+  builder.app.run!
+end
+task.add_description 'rake to-web'

--- a/rake-to-web.gemspec
+++ b/rake-to-web.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Jed Northridge"]
-  s.date = "2013-03-24"
+  s.date = "2013-03-25"
   s.description = "A Web Application that, when started, runs rake -T, and builds routes for each action. POSTing to a route invokes the action."
   s.email = "northridge@gmail.com"
   s.extra_rdoc_files = [
@@ -28,8 +28,7 @@ Gem::Specification.new do |s|
     "lib/rake-to-web.rb",
     "lib/rake_task_manager.rb",
     "lib/task_to_web_builder.rb",
-    "rake-to-web.gemspec",
-    "rakelib/rake-to-web.rake"
+    "rake-to-web.gemspec"
   ]
   s.homepage = "https://github.com/jedcn/rake-to-web"
   s.licenses = ["MIT"]

--- a/rakelib/rake-to-web.rake
+++ b/rakelib/rake-to-web.rake
@@ -1,7 +1,9 @@
-desc 'rake to-web'
-task 'to-web' do
+require 'rake'
+
+task = Rake::Task.define_task 'to-web' do
   require 'rake-to-web'
   rake_task_manager = RakeTaskManager.new
   builder = TaskToWebBuilder.new rake_task_manager
   builder.app.run!
 end
+task.add_description 'rake to-web'

--- a/rakelib/rake-to-web.rake
+++ b/rakelib/rake-to-web.rake
@@ -1,9 +1,0 @@
-require 'rake'
-
-task = Rake::Task.define_task 'to-web' do
-  require 'rake-to-web'
-  rake_task_manager = RakeTaskManager.new
-  builder = TaskToWebBuilder.new rake_task_manager
-  builder.app.run!
-end
-task.add_description 'rake to-web'


### PR DESCRIPTION
It is now the case that if a project calls rake-to-web out as a dependency, and then adds a 'require rake-to-web' then this will create a rake task called 'to-web' so that they can run:

```
rake to-web
```

And have rake-to-web startup on 4567.
