### PR TITLE
Support Namespaced Rake Tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,10 +40,12 @@ task :default => :spec
 require 'rake-to-web'
 
 # Some basic configuration / testing if you run rake to-web locally.
-task :hello_world do
-  puts "HELLO WORLD"
-end
+namespace :examples do
+  task :hello_world do
+    puts "HELLO WORLD"
+  end
 
-task :goodbye_world do
-  puts "GOODBYE WORLD"
+  task :goodbye_world do
+    puts "GOODBYE WORLD"
+  end
 end

--- a/lib/app/views/layout.haml
+++ b/lib/app/views/layout.haml
@@ -12,9 +12,9 @@
           %div.well.sidebar-nav
             %ul.nav.nav-list
               %li.nav-header Rake Tasks
-              - @tasks.each do |task|
+              - @task_names.each do |task_name|
                 %li
-                  %a{ :href => "/#{task.name}" }= task.name
+                  %a{ :href => "/#{task_name}" }= task_name
         %div.span9
           .hero-unit
             = yield

--- a/lib/app/views/result.haml
+++ b/lib/app/views/result.haml
@@ -1,7 +1,7 @@
 %h2 Results
 %p
   Executed
-  %pre= @task.name
+  %pre= @task_name
 %p
   Output
   %pre= @result

--- a/lib/app/views/task.haml
+++ b/lib/app/views/task.haml
@@ -1,6 +1,6 @@
-%h2= "rake #{@task.name}"
-%form{ :action => "/#{@task.name}", :method => 'POST' }
+%h2= "rake #{@task_name}"
+%form{ :action => "/#{@task_name}", :method => 'POST' }
   %input{ :type => "submit", :value => "Execute" }
 
-%form{ :action => "/#{@task.name}.json", :method => 'POST' }
+%form{ :action => "/#{@task_name}.json", :method => 'POST' }
   %input{ :type => "submit", :value => "Execute (JSON Response)" }

--- a/lib/rake_task_manager.rb
+++ b/lib/rake_task_manager.rb
@@ -8,10 +8,6 @@ class RakeTaskManager
     @tasks = Rake.application.tasks
   end
 
-  def tasks
-    @tasks
-  end
-
   def names
     @tasks.collect { |task| encode_task_name task.name }
   end

--- a/lib/rake_task_manager.rb
+++ b/lib/rake_task_manager.rb
@@ -13,11 +13,21 @@ class RakeTaskManager
   end
 
   def names
-    @tasks.collect { |task| task.name }
+    @tasks.collect { |task| encode_task_name task.name }
   end
 
   def run(name)
-    `rake #{name}`
+    `rake #{decode_task_name name}`
+  end
+
+  private
+
+  def encode_task_name(name)
+    name.gsub(':', '/')
+  end
+
+  def decode_task_name(name)
+    name.gsub('/', ':')
   end
 
 end

--- a/lib/task_to_web_builder.rb
+++ b/lib/task_to_web_builder.rb
@@ -10,6 +10,10 @@ class TaskToWebBuilder
   def app
     task_manager = @task_manager
     app = Sinatra.new do
+      tasks = []
+      task_manager.names.each do |name|
+        tasks << OpenStruct.new({ :name => name })
+      end
 
       set :bind, 'localhost'
 
@@ -19,19 +23,19 @@ class TaskToWebBuilder
       set :views, File.join(lib, 'app', 'views')
 
       get('/') do
-        @tasks = task_manager.tasks
+        @tasks = tasks
         haml :index
       end
 
-      task_manager.tasks.each do |task|
+      tasks.each do |task|
 
         get "/#{task.name}" do
-          @tasks, @task = task_manager.tasks, task
+          @tasks, @task = tasks, task
           haml :task
         end
 
         post "/#{task.name}.?:format?" do
-          @tasks, @task = task_manager.tasks, task
+          @tasks, @task = tasks, task
           @result = task_manager.run task.name
           types = %w[text/html application/json]
           if params[:format] == 'json' || request.preferred_type(types) == 'application/json'

--- a/lib/task_to_web_builder.rb
+++ b/lib/task_to_web_builder.rb
@@ -9,11 +9,9 @@ class TaskToWebBuilder
 
   def app
     task_manager = @task_manager
+    task_names = task_manager.names
+
     app = Sinatra.new do
-      tasks = []
-      task_manager.names.each do |name|
-        tasks << OpenStruct.new({ :name => name })
-      end
 
       set :bind, 'localhost'
 
@@ -23,20 +21,20 @@ class TaskToWebBuilder
       set :views, File.join(lib, 'app', 'views')
 
       get('/') do
-        @tasks = tasks
+        @task_names = task_names
         haml :index
       end
 
-      tasks.each do |task|
+      task_names.each do |task_name|
 
-        get "/#{task.name}" do
-          @tasks, @task = tasks, task
+        get "/#{task_name}" do
+          @task_names, @task_name = task_names, task_name
           haml :task
         end
 
-        post "/#{task.name}.?:format?" do
-          @tasks, @task = tasks, task
-          @result = task_manager.run task.name
+        post "/#{task_name}.?:format?" do
+          @task_names, @task_name = task_names, task_name
+          @result = task_manager.run task_name
           types = %w[text/html application/json]
           if params[:format] == 'json' || request.preferred_type(types) == 'application/json'
             content_type :json

--- a/spec/lib/rake_task_manager_spec.rb
+++ b/spec/lib/rake_task_manager_spec.rb
@@ -4,13 +4,13 @@ describe RakeTaskManager do
 
   it 'knows about defined rake tasks' do
     rake_task_manager = RakeTaskManager.new
-    rake_task_manager.names.should include 'hello_world'
+    rake_task_manager.names.should include 'examples/hello_world'
   end
 
   it 'knows how to run defined rake tasks' do
     rake_task_manager = RakeTaskManager.new
-    rake_task_manager.should_receive(:`).with('rake hello_world')
-    rake_task_manager.run 'hello_world'
+    rake_task_manager.should_receive(:`).with('rake examples:hello_world')
+    rake_task_manager.run 'examples/hello_world'
   end
 
 end

--- a/spec/support/simple_task_manager.rb
+++ b/spec/support/simple_task_manager.rb
@@ -11,11 +11,4 @@ class SimpleTaskManager
     end
   end
 
-  def tasks
-    require 'ostruct'
-    tasks = []
-    tasks << OpenStruct.new({ :name => 'multiply_4_by_4' })
-    tasks << OpenStruct.new({ :name => 'add_4_and_4' })
-    tasks
-  end
 end


### PR DESCRIPTION
## Support for Namespaced Rake Tasks

Rake tasks with namespaces look like this:

`rake version:write`

But if you work with Sinatra to create a route with a ":" in it, Sinatra rightly thinks you're talking about a parameter named "write."

At any rate, RakeTaskManager now translates a rake task named `version:write` to `version/write`, and it seems like both parties can live in peace.
## Clarification: tasks + names in TaskManager was confusing

While I was here, I reduced some of the code around TaskManagers and the methods `names` and `tasks`. It used to be that both were used, but `tasks` was heavily relied upon.

I eliminated one of them (`tasks`) and now only `names` remains.

I think this is simpler: `names` returns a list of named tasks (as a list of Strings) and then when someone comes back and asks you it to run a task, they provide a String to `run`.
